### PR TITLE
FA-2127 | Update README for Advising Widget recipe v3

### DIFF
--- a/standardFormats/advising_widget/readme.md
+++ b/standardFormats/advising_widget/readme.md
@@ -1,3 +1,9 @@
+## Important!
+
+Files only need to be provisioned for the Advising Widget if opting for **Appointments** in the recipe.
+
+They are **not required** if Appointments are not selected.
+
 ## File Formatting Notes and Recommendations
 
 - The `datetime` value **must** be ISO-8601 compliant (eg. `YYYY-MM-DDTHH:MM:SSZ`).


### PR DESCRIPTION
This simply adds a bit of preamble to explicitly state the files are only needed if Appointments have been selected in the recipe.