### PR TITLE
REC-944 | Update Faculty Leave Balances spec

### DIFF
--- a/standardFormats/leave_balances_flat_file/leave_balances_data.json
+++ b/standardFormats/leave_balances_flat_file/leave_balances_data.json
@@ -3,30 +3,30 @@
         "alternate_id": "55555",
         "balances": [
             {
-                "leave_type_name": "Sick Leave",
-                "available_balance": "50",
+                "leaveTypeName": "Sick Leave",
+                "availableBalance": "50",
                 "unit": "hours"
             },
             {
-                "leave_type_name": "Vacation",
-                "available_balance": "112",
+                "leaveTypeName": "Vacation",
+                "availableBalance": "112",
                 "unit": "hours"
             }
         ],
         "requests": [
             {
-                "leave_type_name": "Sick Leave",
-                "start_date": "2024-02-02",
-                "end_date": "2024-02-04",
+                "leaveTypeName": "Sick Leave",
+                "startDate": "2024-02-02",
+                "endDate": "2024-02-04",
                 "total": 24,
                 "unit": "hours",
                 "status": "pending",
                 "description": "Feeling unwell, need to recover."
             },
             {
-                "leave_type_name": "Vacation",
-                "start_date": "2028-01-15",
-                "end_date": "2028-01-28",
+                "leaveTypeName": "Vacation",
+                "startDate": "2028-01-15",
+                "endDate": "2028-01-28",
                 "total": 112,
                 "unit": "hours",
                 "status": "denied",


### PR DESCRIPTION
Ticket: https://ucroo-platform.atlassian.net/browse/REC-944

This updates the canonical Faculty Leave Balances data format specification to use camelCase keys instead of snake_case, ensuring consistency with the Universal API standard and the Frontend Widget's native expectations. There is no impact on the Flat File version of the Recipe, nor any existing integrations that use the Flat File version, because it is compatible with both specs.