### PR TITLE
REC-944 | Revert Faculty Leave Balances spec, and add a README.md to clarify

### DIFF
--- a/standardFormats/leave_balances_flat_file/README.md
+++ b/standardFormats/leave_balances_flat_file/README.md
@@ -1,0 +1,5 @@
+## Format Note
+
+This spec uses `snake_case` keys, which is what the Flat File version of the Recipe expects. The **Universal API Faculty Leave Balances Widget Recipe** uses `camelCase` keys instead.
+
+If referencing for the Universal API version, see its Recipe documentation for its specific format, as it is not the same as the Flat File version.

--- a/standardFormats/leave_balances_flat_file/leave_balances_data.json
+++ b/standardFormats/leave_balances_flat_file/leave_balances_data.json
@@ -3,30 +3,30 @@
         "alternate_id": "55555",
         "balances": [
             {
-                "leaveTypeName": "Sick Leave",
-                "availableBalance": "50",
+                "leave_type_name": "Sick Leave",
+                "available_balance": "50",
                 "unit": "hours"
             },
             {
-                "leaveTypeName": "Vacation",
-                "availableBalance": "112",
+                "leave_type_name": "Vacation",
+                "available_balance": "112",
                 "unit": "hours"
             }
         ],
         "requests": [
             {
-                "leaveTypeName": "Sick Leave",
-                "startDate": "2024-02-02",
-                "endDate": "2024-02-04",
+                "leave_type_name": "Sick Leave",
+                "start_date": "2024-02-02",
+                "end_date": "2024-02-04",
                 "total": 24,
                 "unit": "hours",
                 "status": "pending",
                 "description": "Feeling unwell, need to recover."
             },
             {
-                "leaveTypeName": "Vacation",
-                "startDate": "2028-01-15",
-                "endDate": "2028-01-28",
+                "leave_type_name": "Vacation",
+                "start_date": "2028-01-15",
+                "end_date": "2028-01-28",
                 "total": 112,
                 "unit": "hours",
                 "status": "denied",


### PR DESCRIPTION
Ticket (see comment): https://ucroo-platform.atlassian.net/browse/REC-944

This reverts the previous [PR for the (Faculty) Leave Balances spec](https://github.com/ucroo-community/tutorials/pull/29) to once again use `snake_case` keys. It also adds a format note in a README.md file to clarify that the Universal API Recipe uses camelCase instead and to reference its Recipe documentation, as this spec is not the source of truth for that implementation.

This is a tutorial spec file, not a contract. The actual Recipe documentation governs each implementation's format.

This was required because originally either this spec file or the Frontend Recipe were not consistent with each other when they were built, and partially that may have been because the Generic File Reader Recipe (which the Flat File version must use) transforms keys to lowercase.